### PR TITLE
Fix feature selection when no continuous features are available

### DIFF
--- a/src/GAM.svelte
+++ b/src/GAM.svelte
@@ -261,18 +261,17 @@
       });
       targetFeatureIndex = featureSelectList[tempSelectedFeature.type].map(d => d.name).indexOf(lastEditName);
     } else {
-      // Initialize GAM Changer using the continuous variable with the highest importance
-
       if(featureSelectList.continuous.length !== 0) {
+        // Initialize GAM Changer using the continuous variable with the highest importance
         targetFeatureIndex = d3.maxIndex(featureSelectList.continuous, d => d.importance);
         tempSelectedFeature.type = 'continuous';
       } else {
+        // If there is no continuous variable, initialize GAM Changer using
+        // the categorical variable with the highest importance
         targetFeatureIndex = d3.maxIndex(featureSelectList.categorical, d => d.importance);
         tempSelectedFeature.type = 'categorical';
       }
     }
-
-    
 
     tempSelectedFeature.data = data.features[featureSelectList[tempSelectedFeature.type][targetFeatureIndex].featureID];
     tempSelectedFeature.id = featureSelectList[tempSelectedFeature.type][targetFeatureIndex].featureID;

--- a/src/GAM.svelte
+++ b/src/GAM.svelte
@@ -263,12 +263,16 @@
     } else {
       // Initialize GAM Changer using the continuous variable with the highest importance
 
-      targetFeatureIndex = d3.maxIndex(featureSelectList.continuous, d => d.importance);
-      tempSelectedFeature.type = 'continuous';
-
-      // targetFeatureIndex = d3.maxIndex(featureSelectList.categorical, d => d.importance);
-      // tempSelectedFeature.type = 'categorical';
+      if(featureSelectList.continuous.length !== 0) {
+        targetFeatureIndex = d3.maxIndex(featureSelectList.continuous, d => d.importance);
+        tempSelectedFeature.type = 'continuous';
+      } else {
+        targetFeatureIndex = d3.maxIndex(featureSelectList.categorical, d => d.importance);
+        tempSelectedFeature.type = 'categorical';
+      }
     }
+
+    
 
     tempSelectedFeature.data = data.features[featureSelectList[tempSelectedFeature.type][targetFeatureIndex].featureID];
     tempSelectedFeature.id = featureSelectList[tempSelectedFeature.type][targetFeatureIndex].featureID;


### PR DESCRIPTION
I've got a model that has no continuous features. When I use the GAM changer, it fails to initialize the GAM view in the middle of the screen. This PR fixes the behavior so it chooses a categorical feature if no continuous features are available in the dropdown.