### PR TITLE
Add missing arg for wheel event

### DIFF
--- a/src/global-explanation/CatFeature.svelte
+++ b/src/global-explanation/CatFeature.svelte
@@ -350,7 +350,7 @@
       .attr('width', svgWidth)
       .attr('height', svgHeight)
       // WebKit bug workaround (see https://bugs.webkit.org/show_bug.cgi?id=226683)
-      .on('wheel', () => {
+      .on('wheel', (e) => {
         e.preventDefault();
         e.stopPropagation();
       });


### PR DESCRIPTION
One of the event handlers is missing the `e` argument which causes a crash. This PR fixes it!